### PR TITLE
Improve use of subscription fns and with EQL

### DIFF
--- a/src/main/space/matterandvoid/subscriptions/datalevin_eql.clj
+++ b/src/main/space/matterandvoid/subscriptions/datalevin_eql.clj
@@ -2,7 +2,7 @@
   (:require
     [borkdude.dynaload :refer [dynaload]]
     [edn-query-language.core :as eql]
-    [space.matterandvoid.subscriptions.core :refer [reg-sub-raw reg-sub <sub]]
+    [space.matterandvoid.subscriptions.core :refer [reg-sub-raw reg-sub <sub sub-fn]]
     [space.matterandvoid.subscriptions.impl.eql-queries :as impl]
     [space.matterandvoid.subscriptions.impl.reagent-ratom :as r]
     [space.matterandvoid.subscriptions.impl.eql-protocols :as proto]
@@ -79,7 +79,15 @@
 (def class->registry-key impl/class->registry-key)
 (def get-ident impl/get-ident)
 
+(defn create-component-subs
+  "Creates a subscription function that will fulfill the given fulcro component's query.
+  The component and any components in its query must have a name (cannot be anonymous).
+  the `sub-joins-map` argument is a hashmap whose keys are the join properties of the component and whose value is a
+  subscription function for normal joins, and a nested hashmap for unions of the union key to subscription.
+  You do not need to provide a subscription function for recursive joins."
+  [c sub-joins-map] (impl/create-component-subs <sub sub-fn datalevin-data-source c sub-joins-map))
+
 (defn register-component-subs!
   "Registers subscriptions that will fulfill the given fulcro component's query.
   The component must have a name as well as any components in its query."
-  [c] (impl/register-component-subs! reg-sub-raw reg-sub <sub datalevin-data-source c))
+  [c] (impl/register-component-subs! reg-sub-raw <sub datalevin-data-source c))

--- a/src/main/space/matterandvoid/subscriptions/fulcro.cljs
+++ b/src/main/space/matterandvoid/subscriptions/fulcro.cljs
@@ -100,6 +100,17 @@
   ([app] (impl/clear-handlers app))
   ([app id] (impl/clear-handlers app id)))
 
+(defn sub-fn
+  "Takes a function that returns either a Reaction or RCursor. Returns a function that when invoked delegates to `f` and
+   derefs its output. The returned function can be used in subscriptions."
+  [f]
+  (with-meta
+    (fn
+      ([] (deref (f)))
+      ([datasource] (deref (f datasource)))
+      ([datasource args] (deref (f datasource args))))
+    {::subscription f}))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; reactive refresh of components
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/main/space/matterandvoid/subscriptions/fulcro_eql.cljc
+++ b/src/main/space/matterandvoid/subscriptions/fulcro_eql.cljc
@@ -2,7 +2,7 @@
   (:require
     [com.fulcrologic.fulcro.application :as fulcro.app]
     [edn-query-language.core :as eql]
-    [space.matterandvoid.subscriptions.fulcro :refer [reg-sub-raw reg-sub <sub]]
+    [space.matterandvoid.subscriptions.fulcro :refer [reg-sub-raw reg-sub <sub sub-fn]]
     [space.matterandvoid.subscriptions.impl.eql-queries :as impl]
     [space.matterandvoid.subscriptions.impl.eql-protocols :as proto]
     [space.matterandvoid.subscriptions.impl.reagent-ratom :refer [cursor]]
@@ -59,9 +59,9 @@
   the `sub-joins-map` argument is a hashmap whose keys are the join properties of the component and whose value is a
   subscription function for normal joins, and a nested hashmap for unions of the union key to subscription.
   You do not need to provide a subscription function for recursive joins."
-  [c sub-joins-map] (impl/create-component-subs <sub fulcro-data-source c sub-joins-map))
+  [c sub-joins-map] (impl/create-component-subs <sub sub-fn fulcro-data-source c sub-joins-map))
 
 (defn register-component-subs!
   "Registers subscriptions that will fulfill the given fulcro component's query.
   The component and any components in its query must have a name (cannot be anonymous)."
-  [c] (impl/register-component-subs! reg-sub-raw reg-sub <sub fulcro-data-source c))
+  [c] (impl/register-component-subs! reg-sub-raw <sub fulcro-data-source c))

--- a/src/main/space/matterandvoid/subscriptions/impl/core.cljc
+++ b/src/main/space/matterandvoid/subscriptions/impl/core.cljc
@@ -18,7 +18,9 @@
   (swap! handler-registry_ assoc-in (subs-state-path id) (fn [& args] (apply handler-fn args)))
   handler-fn)
 
-(defn get-handler [id] (if (fn? id) (-> id meta :subscription) (get-in @handler-registry_ (subs-state-path id))))
+(defn get-handler [id] (if (fn? id)
+                         (or (-> id meta :space.matterandvoid.subscriptions.core/subscription) id)
+                         (get-in @handler-registry_ (subs-state-path id))))
 
 (defn clear-handlers
   ;; clear all handlers

--- a/src/main/space/matterandvoid/subscriptions/impl/fulcro.cljc
+++ b/src/main/space/matterandvoid/subscriptions/impl/fulcro.cljc
@@ -62,7 +62,7 @@
   Lookup in the place where the query-id -> handler functions are stored."
   [id]
   (if (fn? id)
-    (-> id meta :subscription)
+    (or (-> id meta :space.matterandvoid.subscriptions.fulcro/subscription) id)
     (get-in @handler-registry_ (subs-state-path subs-key id))))
 
 (defn register-handler!

--- a/src/main/space/matterandvoid/subscriptions/impl/hooks_common.cljs
+++ b/src/main/space/matterandvoid/subscriptions/impl/hooks_common.cljs
@@ -5,8 +5,7 @@
     ["use-sync-external-store/shim" :refer [useSyncExternalStore]]
     ["use-sync-external-store/shim/with-selector" :refer [useSyncExternalStoreWithSelector]]
     [goog.object :as gobj]
-    [space.matterandvoid.subscriptions.impl.reagent-ratom :as ratom]
-    [space.matterandvoid.subscriptions.fulcro :as subs]))
+    [space.matterandvoid.subscriptions.impl.reagent-ratom :as ratom]))
 
 ;; The following was adapted from
 ;; https://github.com/roman01la/hooks/blob/1a98408280892da1abebde206b5ca2444aced1b3/src/hooks/impl.cljs

--- a/src/main/space/matterandvoid/subscriptions/impl/subs.cljc
+++ b/src/main/space/matterandvoid/subscriptions/impl/subs.cljc
@@ -61,8 +61,8 @@
         query-id  (first query)
         cache-key (get-cache-key datasource query)]
     (assert (or (= 1 cnt) (= 2 cnt)) (str "Query must contain only one map for subscription " query-id))
-    (when (and (= 2 cnt) (not (map? (get query 1))))
-      (throw (error "Args to the query vector must be one map for subscription " query-id "\n" "Received: " (pr-str (get query 1)))))
+    (when (and (= 2 cnt) (not (or (nil? (get query 1)) (map? (get query 1)))))
+      (throw (error "Args to the query vector must be one map for subscription " query-id "\n" "Received query: " (pr-str query))))
     (trace/with-trace {:operation (first query)
                        :op-type   :sub/create
                        :tags      {:query-v query}}
@@ -240,10 +240,9 @@
        (let [db-ratom (get-input-db-signal app)
              path     (if (fn? path-vec-or-fn) (path-vec-or-fn) path-vec-or-fn)]
          (ratom/cursor db-ratom path)))
-      ([app query-vec]
-       (assert (or (nil? query-vec) (vector? query-vec)))
-       (let [args     (second query-vec)
-             db-ratom (get-input-db-signal app)
+      ([app args]
+       (assert (or (nil? args) (map? args)))
+       (let [db-ratom (get-input-db-signal app)
              path     (if (fn? path-vec-or-fn) (path-vec-or-fn args) path-vec-or-fn)]
          (ratom/cursor db-ratom path))))))
 

--- a/src/main/space/matterandvoid/subscriptions/reagent_ratom.cljc
+++ b/src/main/space/matterandvoid/subscriptions/reagent_ratom.cljc
@@ -1,4 +1,5 @@
 (ns space.matterandvoid.subscriptions.reagent-ratom
+  (:refer-clojure :exclude [atom])
   (:require [space.matterandvoid.subscriptions.impl.reagent-ratom :as ratom]))
 
 (defn atom

--- a/src/main/space/matterandvoid/subscriptions/xtdb_eql.clj
+++ b/src/main/space/matterandvoid/subscriptions/xtdb_eql.clj
@@ -2,7 +2,7 @@
   (:require
     [borkdude.dynaload :refer [dynaload]]
     [edn-query-language.core :as eql]
-    [space.matterandvoid.subscriptions.core :refer [reg-sub-raw reg-sub <sub]]
+    [space.matterandvoid.subscriptions.core :refer [reg-sub-raw reg-sub <sub sub-fn]]
     [space.matterandvoid.subscriptions.impl.eql-protocols :as proto]
     [space.matterandvoid.subscriptions.impl.eql-queries :as impl]
     [space.matterandvoid.subscriptions.impl.reagent-ratom :as r :refer [make-reaction]]
@@ -64,7 +64,15 @@
 (def class->registry-key impl/class->registry-key)
 (def get-ident impl/get-ident)
 
+(defn create-component-subs
+  "Creates a subscription function that will fulfill the given fulcro component's query.
+  The component and any components in its query must have a name (cannot be anonymous).
+  the `sub-joins-map` argument is a hashmap whose keys are the join properties of the component and whose value is a
+  subscription function for normal joins, and a nested hashmap for unions of the union key to subscription.
+  You do not need to provide a subscription function for recursive joins."
+  [c sub-joins-map] (impl/create-component-subs <sub sub-fn xtdb-data-source c sub-joins-map))
+
 (defn register-component-subs!
   "Registers subscriptions that will fulfill the given fulcro component's query.
   The component must have a name as well as any components in its query."
-  [c] (impl/register-component-subs! reg-sub-raw reg-sub <sub xtdb-data-source c))
+  [c] (impl/register-component-subs! reg-sub-raw <sub xtdb-data-source c))

--- a/src/test/space/matterandvoid/subscriptions/subs_test.cljs
+++ b/src/test/space/matterandvoid/subscriptions/subs_test.cljs
@@ -38,7 +38,7 @@
   (let [counter_ (volatile! 0)
         add      (fn add [x y]
                    (vswap! counter_ inc)
-                   (println "EXECUTING") (+ x y))
+                   (+ x y))
         mem-add  (memoize-fn {:max-args-cached-size 2 :max-history-size 3} add)]
     (mem-add 1 1) (mem-add 1 1) (mem-add 1 1) (mem-add 1 1) (mem-add 1 1)
     (is (= 1 @counter_))))


### PR DESCRIPTION
Update docs on usage of subscription functions. Have EQL entity subscription functions use `sub-fn` to allow invoking directly.