### PR TITLE
Layer2 fix and fulcro forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -551,6 +551,29 @@ example:
 (<sub db_ [sorted-todos])
 ```
 
+## `deflayer2-sub` macro
+
+For use without a subscription registry. When using a subscription registry see the `reg-layer2-sub` function.
+
+For "layer2" subscriptions this library supports returning a Reagent RCursor type instead of a Reaction.
+
+This helper lets you just return a path instead of the cursor itself:
+
+For convenience you can provide
+- a single keyword
+- a vector path
+- a function which takes your db-atom and an optional arguments hashmap passed to `subscribe` and returns a vector path
+
+The function form lets you do things like store the cursor path in the db itself, for example a pointer (ref) to an entity.
+
+Examples:
+
+```clojure
+(deflayer2-sub a-sub :some-value)
+(deflayer2-sub my-todo [:todo/id 1234])
+(deflayer2-sub form-todo (fn [db_ args-map] (:root/new-todo-ref @db_)))
+```
+
 # Implementation details
 
 The codebase is quite tiny (the impl.subs namespace, pretty much the same as in re-frame), but if you haven't played with 

--- a/docs/eql_queries.md
+++ b/docs/eql_queries.md
@@ -264,13 +264,17 @@ The `todo-sub`'s joins map has a second level of nesting for the `:todo/author` 
 for a specific todo (`[:bot/id :bot-id-1]` or `[:user/id :user-id-1]` for example) the appropriate subscription will be used 
 to fulfill the rest of the query.
 
-To subscribe to these you pass the function to `subscribe` or `<sub` functions.
+To subscribe to these you pass the function to `subscribe` or `<sub` functions - or invoke them directly.
 
 Here was ask for the appropriate name, based on the type of the author found for the todo with id `:todo-1`:
 
 ```clojure
-(<sub [todo-sub {:todo/id :todo-1 query-key [{:todo/author {:bot/id [:bot/name]
+(<sub db_ [todo-sub {:todo/id :todo-1 query-key [{:todo/author {:bot/id [:bot/name]
                                                             :user/id [:user/name]}}]}])
+;; or invoke directly:
+
+(todo-sub db_ {:todo/id :todo-1 query-key [{:todo/author {:bot/id [:bot/name]
+                                                          :user/id [:user/name]}}]})
 ```
 which would return `{:todo/author {:bot/name "bot"}}` if a bot ref is found and `{:todo/author {:user/name "user"}}` if a user ref is found.
 

--- a/examples/hooks_example.cljs
+++ b/examples/hooks_example.cljs
@@ -73,7 +73,7 @@
 
   )
 
-(reg-layer2-sub ::lvl2-cursor (fn [args] [:level1 (:key args)]))
+(reg-layer2-sub ::lvl2-cursor (fn [_db args] [:level1 (:key args)]))
 (reg-layer2-sub ::lvl2-cursor2 [:level1 :level2])
 (reg-layer2-sub `lvl2-cursor2 [:level1 :level2])
 (reg-sub :plus-level3 :<- [::lvl2-cursor2] :-> (fn [{:keys [level3]}]

--- a/src/main/space/matterandvoid/subscriptions/core.cljc
+++ b/src/main/space/matterandvoid/subscriptions/core.cljc
@@ -48,6 +48,9 @@
   (apply impl/reg-sub query-id args))
 
 (defn reg-layer2-sub
+  "Registers a handler function that returns a Reagent RCursor instead of a Reagent Reaction.
+  Accepts a single keyword, a vector path into or a function which takes your db atom and arguments map passed to subscribe
+  and must return a vector path to be used for the cursor."
   [query-id path-vec-or-fn]
   (impl/reg-layer2-sub query-id path-vec-or-fn))
 
@@ -148,7 +151,7 @@
 
      Takes a symbol for a subscription name and a way to derive a path in your datasource hashmap. Returns a function subscription
      which itself returns a Reagent RCursor.
-     Supports a vector path, a single keyword, or a function which takes the arguments map passed to subscribe and
+     Supports a vector path, a single keyword, or a function which takes the RAtom datasource and the arguments map passed to subscribe and
      must return a path vector to use as an RCursor path.
 
      Examples:
@@ -157,7 +160,7 @@
 
      (deflayer2-sub my-subscription [:a-path-in-your-db])
 
-     (deflayer2-sub my-subscription (fn [sub-args-map] [:a-key (:some-val sub-args-map])))
+     (deflayer2-sub my-subscription (fn [db-atom sub-args-map] [:a-key (:some-val sub-args-map])))
      "
      [sub-name ?path] `(impl/deflayer2-sub ::subscription ~sub-name ~?path)))
 

--- a/src/main/space/matterandvoid/subscriptions/fulcro.clj
+++ b/src/main/space/matterandvoid/subscriptions/fulcro.clj
@@ -265,7 +265,7 @@
 (defmacro deflayer2-sub
   "Takes a symbol for a subscription name and a way to derive a path in your fulcro app db. Returns a function subscription
   which itself returns a Reagent RCursor.
-  Supports a vector path, a single keyword, or a function which takes the arguments map passed to subscribe and
+  Supports a vector path, a single keyword, or a function which takes the RAtom datasource and the arguments map passed to subscribe and
   must return a path vector to use as an RCursor path.
 
   Examples:
@@ -274,7 +274,7 @@
 
   (deflayer2-sub my-subscription [:a-path-in-your-db])
 
-  (deflayer2-sub my-subscription (fn [sub-args-map] [:a-key (:some-val sub-args-map])))
+  (deflayer2-sub my-subscription (fn [db-atom sub-args-map] [:a-key (:some-val sub-args-map])))
   "
   [sub-name ?path] `(impl/deflayer2-sub ::subscription ~sub-name ~?path))
 

--- a/src/main/space/matterandvoid/subscriptions/fulcro.cljs
+++ b/src/main/space/matterandvoid/subscriptions/fulcro.cljs
@@ -53,6 +53,13 @@
   [query-id & args]
   (apply impl/reg-sub query-id args))
 
+(defn reg-layer2-sub
+  "Registers a handler function that returns a Reagent RCursor instead of a Reagent Reaction.
+  Accepts a single keyword, a vector path into or a function which takes your db atom and arguments map passed to subscribe
+  and must return a vector path to be used for the cursor."
+  [query-id path-vec-or-fn]
+  (impl/reg-layer2-sub query-id path-vec-or-fn))
+
 (defn subscribe
   "Given a `query` vector, returns a Reagent `reaction` which will, over
   time, reactively deliver a stream of values. Also known as a `Signal`.

--- a/src/main/space/matterandvoid/subscriptions/fulcro_eql.cljc
+++ b/src/main/space/matterandvoid/subscriptions/fulcro_eql.cljc
@@ -51,6 +51,15 @@
 (def class->registry-key impl/class->registry-key)
 (def get-ident impl/get-ident)
 
+;; todo here you want to also create form config subs for these:
+;; {:com.fulcrologic.fulcro.algorithms.form-state/config [:com.fulcrologic.fulcro.algorithms.form-state/id
+;                                                         :com.fulcrologic.fulcro.algorithms.form-state/fields
+;                                                         :com.fulcrologic.fulcro.algorithms.form-state/complete?
+;                                                         :com.fulcrologic.fulcro.algorithms.form-state/subforms
+;                                                         :com.fulcrologic.fulcro.algorithms.form-state/pristine-state]}
+; this way you can use these eql subs instead of db->tree
+; but not in impl because they are fulcro specific
+
 (defn create-component-subs
   "Creates a subscription function that will fulfill the given fulcro component's query.
   The component and any components in its query must have a name (cannot be anonymous).

--- a/src/main/space/matterandvoid/subscriptions/fulcro_eql.cljc
+++ b/src/main/space/matterandvoid/subscriptions/fulcro_eql.cljc
@@ -1,11 +1,14 @@
 (ns space.matterandvoid.subscriptions.fulcro-eql
   (:require
+    [com.fulcrologic.fulcro.algorithms.form-state :as fs]
     [com.fulcrologic.fulcro.application :as fulcro.app]
+    [com.fulcrologic.fulcro.raw.components :as rc]
     [edn-query-language.core :as eql]
-    [space.matterandvoid.subscriptions.fulcro :refer [reg-sub-raw <sub sub-fn]]
-    [space.matterandvoid.subscriptions.impl.eql-queries :as impl]
+    [space.matterandvoid.subscriptions.fulcro :refer [<sub reg-sub-raw sub-fn]]
     [space.matterandvoid.subscriptions.impl.eql-protocols :as proto]
-    [space.matterandvoid.subscriptions.impl.reagent-ratom :refer [cursor]]))
+    [space.matterandvoid.subscriptions.impl.eql-queries :as impl]
+    [space.matterandvoid.subscriptions.impl.reagent-ratom :refer [cursor]]
+    [space.matterandvoid.subscriptions.reagent-ratom :as ratom]))
 
 (def query-key impl/query-key)
 (def missing-val impl/missing-val)
@@ -51,22 +54,39 @@
 (def class->registry-key impl/class->registry-key)
 (def get-ident impl/get-ident)
 
-;; todo here you want to also create form config subs for these:
-;; {:com.fulcrologic.fulcro.algorithms.form-state/config [:com.fulcrologic.fulcro.algorithms.form-state/id
-;                                                         :com.fulcrologic.fulcro.algorithms.form-state/fields
-;                                                         :com.fulcrologic.fulcro.algorithms.form-state/complete?
-;                                                         :com.fulcrologic.fulcro.algorithms.form-state/subforms
-;                                                         :com.fulcrologic.fulcro.algorithms.form-state/pristine-state]}
-; this way you can use these eql subs instead of db->tree
-; but not in impl because they are fulcro specific
+(def ^:private fulcro-form-state-config-sub (impl/create-component-subs <sub sub-fn fulcro-data-source fs/FormConfig {}))
+
+(defn ^:private query-contains-form-config? [component]
+  (-> (rc/get-query component)
+    (eql/focus-subquery [fs/form-config-join])
+    not-empty
+    boolean))
+
+(defn expand-ident-list-sub
+  "Takes a layer2 subscription function and an eql subscription for a component.
+  Returns a function subscription that invokes the eql subscription for each ident in the list of idents returned from the provided `layer2-sub`."
+  [layer2-sub component-eql-sub]
+  (fn expand-ident-list [fulcro-app args]
+    (let [component (-> component-eql-sub meta ::impl/component)]
+      (ratom/make-reaction
+        (fn []
+          (let [idents          (layer2-sub fulcro-app args)
+                component-query (rc/get-query component (fulcro.app/current-state fulcro-app))]
+            (mapv (fn [[id-attr id-value]]
+                    (component-eql-sub fulcro-app {query-key component-query, id-attr id-value}))
+                  idents)))))))
 
 (defn create-component-subs
-  "Creates a subscription function that will fulfill the given fulcro component's query.
+  "Creates a subscription function that will fulfill the given Fulcro component's query.
   The component and any components in its query must have a name (cannot be anonymous).
   the `sub-joins-map` argument is a hashmap whose keys are the join properties of the component and whose value is a
   subscription function for normal joins, and a nested hashmap for unions of the union key to subscription.
-  You do not need to provide a subscription function for recursive joins."
-  [c sub-joins-map] (impl/create-component-subs <sub sub-fn fulcro-data-source c sub-joins-map))
+  You do not need to provide a subscription function for recursive joins.
+  You do not need to provide a subscription for Fulcro's form-state config join if you component includes that join in its query,
+  a subscription will be created for you for form-state/config."
+  [component sub-joins-map]
+  (let [sub-joins-map (cond-> sub-joins-map (query-contains-form-config? component) (assoc ::fs/config fulcro-form-state-config-sub))]
+    (impl/create-component-subs <sub sub-fn fulcro-data-source component sub-joins-map)))
 
 (defn register-component-subs!
   "Registers subscriptions that will fulfill the given fulcro component's query.

--- a/src/main/space/matterandvoid/subscriptions/impl/core.cljc
+++ b/src/main/space/matterandvoid/subscriptions/impl/core.cljc
@@ -44,6 +44,9 @@
     query-id args))
 
 (defn reg-layer2-sub
+  "Registers a handler function that returns a Reagent RCursor instead of a Reagent Reaction.
+  Accepts a single keyword, a vector path into or a function which takes your db atom and arguments map passed to subscribe
+  and must return a vector path to be used for the cursor."
   [query-id path-vec-or-fn]
   (subs/reg-layer2-sub
     get-input-db-signal register-handler!
@@ -61,7 +64,7 @@
 
      Takes a symbol for a subscription name and a way to derive a path in your datasource hashmap. Returns a function subscription
      which itself returns a Reagent RCursor.
-     Supports a vector path, a single keyword, or a function which takes the arguments map passed to subscribe and
+     Supports a vector path, a single keyword, or a function which takes the RAtom datasource and the arguments map passed to subscribe and
      must return a path vector to use as an RCursor path.
 
      Examples:
@@ -70,7 +73,7 @@
 
      (deflayer2-sub my-subscription [:a-path-in-your-db])
 
-     (deflayer2-sub my-subscription (fn [sub-args-map] [:a-key (:some-val sub-args-map])))
+     (deflayer2-sub my-subscription (fn [db-atom sub-args-map] [:a-key (:some-val sub-args-map])))
      "
      [meta-sub-kw sub-name ?path]
      `(subs/deflayer2-sub ~meta-sub-kw get-input-db-signal ~sub-name ~?path)))

--- a/src/main/space/matterandvoid/subscriptions/impl/eql_queries.cljc
+++ b/src/main/space/matterandvoid/subscriptions/impl/eql_queries.cljc
@@ -133,26 +133,25 @@
   [<sub sub-fn datasource id-attr props attr-kw->sub-fn]
   (let [f
         (fn [app args]
-          (log/debug "in sub-entity. id attr" id-attr)
+          ;(log/debug "in sub-entity. id attr" id-attr)
           (if (some? (get args query-key))
             (let [props->ast  (eql-by-key (get args query-key args))
                   props'      (keys (dissoc props->ast '*))
                   query       (get args query-key)
                   star-query? (some? (get props->ast '*))]
-              (log/debug "\n\n------ENTITY sub have query" (pr-str query))
+              ;(log/debug "\n\n------ENTITY sub have query" (pr-str query))
               (make-reaction
                 (fn []
                   (let [all-props (if star-query? (get-all-props-shallow datasource app id-attr props args) nil)
                         output
                                   (if (or (nil? query) (= query '[*]))
                                     (do
-                                      (log/debug "entity in first else")
+                                      ;(log/debug "entity in first else")
                                       (proto/-entity datasource app id-attr args))
                                     (do
-                                      (log/debug "entity in 2nd else")
-
+                                      ;(log/debug "entity in 2nd else")
                                       (reduce (fn [acc prop]
-                                                (log/debug "look up prop: " prop " in map: " attr-kw->sub-fn)
+                                                ;(log/debug "look up prop: " prop " in map: " attr-kw->sub-fn)
                                                 (when-not (get attr-kw->sub-fn prop)
                                                   (throw (error "Missing subscription for entity prop: " prop)))
                                                 (let [prop-sub-fn (get attr-kw->sub-fn prop)
@@ -164,12 +163,12 @@
                                                     (not= missing-val output)
                                                     (assoc prop output))))
                                         {} props')))
-                        _         (log/debug "entity output1: " output)
+                        ;_         (log/debug "entity output1: " output)
                         output    (merge all-props output)]
-                    _ (log/debug "entity output2: " output)
+                    ;(log/debug "entity output2: " output)
                     output))))
             (do
-              (log/debug "ENTITY SUB NO QUERY: selecting props " props)
+              ;(log/debug "ENTITY SUB NO QUERY: selecting props " props)
               (make-reaction (fn [] (reduce (fn [acc prop]
                                               (let [prop-sub-fn (get attr-kw->sub-fn prop)]
                                                 (assoc acc prop (<sub app [prop-sub-fn args]))))
@@ -510,7 +509,7 @@
           union-join-subs (zipmap (map first union-joins) (map (fn [[p component-sub]] (sub-union-join <sub datasource id-attr p component-sub)) union-joins))
           recur-join-subs (zipmap (map first recur-joins) (map (fn [[p]] (sub-recur-join <sub datasource id-attr p recur-join-fn_)) recur-joins))
           kw->sub-fn      (merge prop-subs plain-join-subs union-join-subs recur-join-subs)
-          entity-sub      (sub-entity <sub sub-fn datasource id-attr all-children kw->sub-fn)]
+          entity-sub      (vary-meta (sub-entity <sub sub-fn datasource id-attr all-children kw->sub-fn) assoc ::component c)]
       (reset! recur-join-fn_ entity-sub)
       entity-sub)))
 

--- a/src/main/space/matterandvoid/subscriptions/impl/fulcro.cljc
+++ b/src/main/space/matterandvoid/subscriptions/impl/fulcro.cljc
@@ -106,6 +106,15 @@
     get-input-db-signal get-handler register-handler! get-subscription-cache cache-lookup get-cache-key
     query-id args))
 
+(defn reg-layer2-sub
+  "Registers a handler function that returns a Reagent RCursor instead of a Reagent Reaction.
+  Accepts a single keyword, a vector path into or a function which takes your db atom and arguments map passed to subscribe
+  and must return a vector path to be used for the cursor."
+  [query-id path-vec-or-fn]
+  (subs/reg-layer2-sub
+    get-input-db-signal register-handler!
+    query-id path-vec-or-fn))
+
 (defn subscribe
   "Given a `query` vector, returns a Reagent `reaction` which will, over
   time, reactively deliver a stream of values. Also known as a `Signal`.
@@ -141,7 +150,7 @@
    (defmacro deflayer2-sub
      "Takes a symbol for a subscription name and a way to derive a path in your fulcro app db. Returns a function subscription
      which itself returns a Reagent RCursor.
-     Supports a vector path, a single keyword, or a function which takes the arguments map passed to subscribe and
+     Supports a vector path, a single keyword, or a function which takes the RAtom datasource and the arguments map passed to subscribe and
      must return a path vector to use as an RCursor path.
 
      Examples:
@@ -150,7 +159,7 @@
 
      (deflayer2-sub my-subscription [:a-path-in-your-db])
 
-     (deflayer2-sub my-subscription (fn [sub-args-map] [:a-key (:some-val sub-args-map])))
+     (deflayer2-sub my-subscription (fn [db-atom sub-args-map] [:a-key (:some-val sub-args-map])))
      "
      [meta-sub-kw sub-name ?path]
      `(subs/deflayer2-sub ~meta-sub-kw get-input-db-signal ~sub-name ~?path)))

--- a/src/test/space/matterandvoid/subscriptions/core_test.cljc
+++ b/src/test/space/matterandvoid/subscriptions/core_test.cljc
@@ -16,9 +16,10 @@
 (sut/defsub layer3-def2 :<- [sub2'] :-> #(* 10 %))
 
 (sut/reg-layer2-sub ::sub-2-accessor [:sub2])
+(sut/reg-layer2-sub ::sub-2-accessor-5 (fn [_db _args] [:sub2]))
 (sut/deflayer2-sub sub-2-accessor-2 [:sub2])
 (sut/deflayer2-sub sub-2-accessor-3 :sub2)
-(sut/deflayer2-sub sub-2-accessor-4 (fn [args] [(:kw args)]))
+(sut/deflayer2-sub sub-2-accessor-4 (fn [_db args] [(:kw args)]))
 (sut/defsub layer3-def3 :<- [layer3-def2] :<- [layer3-def1] :-> #(apply + %))
 (sut/defsub layer3-def4 :<- [layer3-def2] :<- [layer3-def1] :-> (fn [a] (apply + a)))
 (sut/defsub layer3-def5 :<- [layer3-def2] :<- [layer3-def1] (fn [a] (apply + a)))
@@ -74,6 +75,7 @@
 
 (deftest basic-test
   (is (= 500 (sut/<sub db [::sub-2-accessor])))
+  (is (= 500 (sut/<sub db [::sub-2-accessor-5])))
   (is (= 500 (sut/<sub db [sub-2-accessor-2])))
   (is (= 500 (sut/<sub db [sub-2-accessor-2 {}])))
   (is (= 500 (sut/<sub db [sub-2-accessor-3])))

--- a/src/test/space/matterandvoid/subscriptions/fulcro_eql_fn_vars_test.cljc
+++ b/src/test/space/matterandvoid/subscriptions/fulcro_eql_fn_vars_test.cljc
@@ -1,11 +1,13 @@
 (ns space.matterandvoid.subscriptions.fulcro-eql-fn-vars-test
   (:require
+    [clojure.test :refer [deftest is testing]]
+    [com.fulcrologic.fulcro.algorithms.form-state :as fs]
+    [com.fulcrologic.fulcro.application :as fulcro.app]
+    [com.fulcrologic.fulcro.raw.components :as rc]
+    [space.matterandvoid.subscriptions.fulcro :refer [<sub]]
     [space.matterandvoid.subscriptions.fulcro-eql :as sut]
     [space.matterandvoid.subscriptions.impl.reagent-ratom :as r]
-    [space.matterandvoid.subscriptions.fulcro :refer [<sub]]
-    [com.fulcrologic.fulcro.application :as fulcro.app]
-    [taoensso.timbre :as log]
-    [clojure.test :refer [deftest is testing]]))
+    [taoensso.timbre :as log]))
 
 (log/set-level! :debug)
 #?(:cljs (enable-console-print!))
@@ -39,6 +41,14 @@
                                                     :todo/author   {:bot/id bot-sub :user/id user-sub}}))
 (def list-sub (sut/create-component-subs list-comp {:list/items   {:comment/id comment-sub :todo/id todo-sub}
                                                     :list/members {:comment/id comment-sub :todo/id todo-sub}}))
+
+(def todo-with-form-component
+  (sut/nc
+    {:query       [:todo/id :todo/text fs/form-config-join], :name ::todo-with-form, :ident :todo/id,
+     :form-fields #{:todo/text}}))
+
+(def todo-with-form-sub (sut/create-component-subs todo-with-form-component {}))
+
 (comment
   (sut/eql-query-keys-by-type (sut/get-query todo-comp) {:todo/comment  comment-sub
                                                          :todo/comments comment-sub
@@ -46,11 +56,7 @@
   (def todo-sub (sut/create-component-subs todo-comp nil)))
 
 ;(def list-sub (sut/create-component-subs list-comp nil))
-
-
 ;(run! sut/register-component-subs! [user-comp bot-comp comment-comp todo-comp list-comp human-comp])
-
-;; todo - use merge-component with form-state and test fulcro form-state/config join returns data correctly.
 
 (def db_ (r/atom {:comment/id {:comment-1 {:comment/id           :comment-1 :comment/text "FIRST COMMENT"
                                            :comment/author       [:user/id :user-1]
@@ -78,6 +84,15 @@
                                :todo-3 {:todo/id :todo-3 :todo/text "todo 3" :todo/comments [[:comment/id :comment-1] [:comment/id :comment-3]]}}}))
 
 (def app (assoc (fulcro.app/fulcro-app {}) ::fulcro.app/state-atom db_))
+
+(let [todo-w-form-ident [:todo/id :todo-with-form]
+      todo-w-form       {:todo/id :todo-with-form :todo/text "todo with-form"}]
+  (swap! (::fulcro.app/state-atom app)
+    (fn [state]
+      (-> state
+        (assoc-in todo-w-form-ident todo-w-form)
+        (fs/add-form-config* todo-with-form-component todo-w-form-ident)))))
+
 (comment
   ;; wow. it works....
   (bot-sub app {:bot/id :bot-1})
@@ -239,6 +254,15 @@
            :list/name    "first list",
            :list/id      :list-1}
           (<sub app [list-sub {:list/id :list-1}])))))
+
+(deftest form-state-test
+  (is (=
+        {:todo/id    :todo-with-form,
+         :todo/text  "todo with-form",
+         ::fs/config {::fs/id         [:todo/id :todo-with-form], ::fs/fields #{:todo/text}, ::fs/complete? nil, ::fs/subforms {},
+                      ::fs/pristine-state {:todo/text "todo with-form"}}}
+        (todo-with-form-sub app {:todo/id      :todo-with-form
+                                 sut/query-key (rc/get-query todo-with-form-component)}))))
 
 (comment
   (<sub app [list-sub {:list/id :list-1 sut/query-key [{:list/items list-member-q}

--- a/src/test/space/matterandvoid/subscriptions/fulcro_eql_fn_vars_test.cljc
+++ b/src/test/space/matterandvoid/subscriptions/fulcro_eql_fn_vars_test.cljc
@@ -50,6 +50,8 @@
 
 ;(run! sut/register-component-subs! [user-comp bot-comp comment-comp todo-comp list-comp human-comp])
 
+;; todo - use merge-component with form-state and test fulcro form-state/config join returns data correctly.
+
 (def db_ (r/atom {:comment/id {:comment-1 {:comment/id           :comment-1 :comment/text "FIRST COMMENT"
                                            :comment/author       [:user/id :user-1]
                                            :comment/sub-comments [[:comment/id :comment-2]]}

--- a/src/test/space/matterandvoid/subscriptions/fulcro_test.cljc
+++ b/src/test/space/matterandvoid/subscriptions/fulcro_test.cljc
@@ -26,7 +26,9 @@
 
 (sut/deflayer2-sub acc1 :first)
 (sut/deflayer2-sub acc1' [:first])
-(sut/deflayer2-sub acc1'' (fn [args] [(:kw args)]))
+(sut/deflayer2-sub acc1'' (fn [_db args] [(:kw args)]))
+
+(sut/reg-layer2-sub ::sub-2-accessor-5 (fn [_db _args] [:first]))
 
 (sut/reg-sub ::second :<- [::first]
   (fn [args]
@@ -63,6 +65,7 @@
         out6 (sut/<sub (fulcro.app/current-state app) [::fifth])
         a    (sut/<sub app [::a])]
     (is (= out1 500))
+    (is (= 500 (sut/<sub app [::sub-2-accessor-5])))
     (is (= 500 (sut/<sub app [acc1])))
     (is (= 500 (sut/<sub app [acc1 nil])))
     (is (= 500 (sut/<sub app [acc1'])))


### PR DESCRIPTION
- Update `deflayer2-sub` to take the app db as its first arg when using a function.
- Add fulcro form state config support to fulcro-eql.
- Add fulcro helper to make a subscription that expands a list of idents using a component subscription.