### PR TITLE
Macro updates

### DIFF
--- a/src/main/space/matterandvoid/subscriptions/core.cljc
+++ b/src/main/space/matterandvoid/subscriptions/core.cljc
@@ -112,39 +112,16 @@
             ([app#] (deref (subscribe app# [~sub-kw])))
             ([app# args#] (deref (subscribe app# [~sub-kw args#]))))))))
 
+(defn make-sub-fn [query-id sub-args]
+  (impl/make-sub-fn ::subscription query-id sub-args))
+
 #?(:clj
    (defmacro defsub
-     "Has the same function signature as `reg-sub`.
+     "Has the same function signature as `reg-sub` without a keyword name argument.
      Returns a subscription function and creates a function which invokes subscribe and deref on the registered subscription
      with the args map passed in."
      [fn-name & args]
-     (let [compute-fn' (gensym "compute-fn")
-           inputs'     (gensym "inputs")
-           sub-args'   (gensym "sub-args")]
-       `(let [[inputs-fn# ~compute-fn'] (impl/parse-reg-sub-args ~(vec args))
-              subscription-fn#
-              (fn ~fn-name
-                ([datasource#]
-                 (let [input-subscriptions# (inputs-fn# datasource#)]
-                   (ratom/make-reaction
-                     (fn [] (~compute-fn' (impl/deref-input-signals input-subscriptions# (str *ns* "/" '~fn-name)))))))
-
-                ([datasource# ~sub-args']
-                 (let [input-subscriptions# (inputs-fn# datasource# ~sub-args')]
-                   (ratom/make-reaction
-                     (fn [] (let [~inputs' (impl/deref-input-signals input-subscriptions# (str *ns* "/" '~fn-name))]
-                              ~(if (:ns &env)
-                                 `(~compute-fn' ~inputs' ~sub-args')
-                                 `(try (~compute-fn' ~inputs' ~sub-args')
-                                       (catch clojure.lang.ArityException ~'_
-                                         (~compute-fn' ~inputs'))))))))))]
-          (def ~fn-name
-            (with-meta
-              (fn ~fn-name
-                ([datasource#] (deref (subscription-fn# datasource#)))
-                ([datasource# args#] (deref (subscription-fn# datasource# args#))))
-              {::subscription subscription-fn#
-               ::sub-name     ~(keyword (str *ns*) (str fn-name))}))))))
+     `(def ~fn-name (make-sub-fn ~(keyword (str *ns*) (str fn-name)) ~(vec args)))))
 
 #?(:clj
    (defmacro deflayer2-sub

--- a/src/main/space/matterandvoid/subscriptions/fulcro.clj
+++ b/src/main/space/matterandvoid/subscriptions/fulcro.clj
@@ -229,7 +229,7 @@
          ([app#] (deref (subscribe app# [~sub-kw])))
          ([app# args#] (deref (subscribe app# [~sub-kw args#])))))))
 
-(defmacro defsub
+(defmacro defsub-orig
   "Has the same function signature as `reg-sub`.
   Returns a subscription function and creates a function which invokes subscribe and deref on the registered subscription
   with the args map passed in."
@@ -262,6 +262,13 @@
              ([datasource# args#] (deref (subscription-fn# datasource# args#))))
            {::subscription subscription-fn#
             ::sub-name     ~(keyword (str *ns*) (str fn-name))})))))
+
+(defmacro defsub
+  "Has the same function signature as `reg-sub`.
+  Returns a subscription function and creates a function which invokes subscribe and deref on the registered subscription
+  with the args map passed in."
+  [fn-name & args]
+  `(def ~fn-name (make-sub-fn ~(keyword (str *ns*) (str fn-name)) ~(vec args))))
 
 (defmacro defsubraw
   "Creates a subscription function that takes the datasource ratom and optionally an args map and returns a Reaction."

--- a/src/main/space/matterandvoid/subscriptions/fulcro.clj
+++ b/src/main/space/matterandvoid/subscriptions/fulcro.clj
@@ -229,42 +229,11 @@
          ([app#] (deref (subscribe app# [~sub-kw])))
          ([app# args#] (deref (subscribe app# [~sub-kw args#])))))))
 
-(defmacro defsub-orig
-  "Has the same function signature as `reg-sub`.
-  Returns a subscription function and creates a function which invokes subscribe and deref on the registered subscription
-  with the args map passed in."
-  [fn-name & args]
-  (let [compute-fn' (gensym "compute-fn")
-        inputs'     (gensym "inputs")
-        sub-args'   (gensym "sub-args")]
-    `(let [[inputs-fn# ~compute-fn'] (impl/parse-reg-sub-args ~(vec args))
-           subscription-fn#
-           (fn ~fn-name
-
-             ([datasource#]
-              (let [input-subscriptions# (inputs-fn# datasource#)]
-                (ratom/make-reaction
-                  (fn [] (~compute-fn' (impl/deref-input-signals input-subscriptions# (str *ns* "/" '~fn-name)))))))
-
-             ([datasource# ~sub-args']
-              (let [input-subscriptions# (inputs-fn# datasource# ~sub-args')]
-                (ratom/make-reaction
-                  (fn [] (let [~inputs' (impl/deref-input-signals input-subscriptions# (str *ns* "/" '~fn-name))]
-                           ~(if (:ns &env)
-                              `(~compute-fn' ~inputs' ~sub-args')
-                              `(try (~compute-fn' ~inputs' ~sub-args')
-                                    (catch clojure.lang.ArityException ~'_
-                                      (~compute-fn' ~inputs'))))))))))]
-       (def ~fn-name
-         (with-meta
-           (fn ~fn-name
-             ([datasource#] (deref (subscription-fn# datasource#)))
-             ([datasource# args#] (deref (subscription-fn# datasource# args#))))
-           {::subscription subscription-fn#
-            ::sub-name     ~(keyword (str *ns*) (str fn-name))})))))
+(defn make-sub-fn [query-id sub-args]
+  (impl/make-sub-fn ::subscription query-id sub-args))
 
 (defmacro defsub
-  "Has the same function signature as `reg-sub`.
+  "Has the same function signature as `reg-sub` without a keyword name argument.
   Returns a subscription function and creates a function which invokes subscribe and deref on the registered subscription
   with the args map passed in."
   [fn-name & args]

--- a/src/main/space/matterandvoid/subscriptions/fulcro.cljs
+++ b/src/main/space/matterandvoid/subscriptions/fulcro.cljs
@@ -115,33 +115,8 @@
   [f sub-name]
   (vary-meta f assoc ::sub-name sub-name))
 
-(defn make-sub-fn
-  [query-id sub-args]
-  (let [[inputs-fn compute-fn] (impl/parse-reg-sub-args sub-args)
-        subscription-fn
-        (fn sub-fn
-          ([datasource]
-           (let [input-subscriptions (inputs-fn datasource)]
-             (ratom/make-reaction
-               (fn [] (compute-fn (impl/deref-input-signals input-subscriptions query-id))))))
-
-          ([datasource sub-args]
-           (let [input-subscriptions (inputs-fn datasource sub-args)]
-             (ratom/make-reaction
-               (fn [] (let [inputs (impl/deref-input-signals input-subscriptions query-id)]
-                        (compute-fn inputs sub-args)))))))]
-    (with-meta
-      (fn sub-fn
-        ([datasource] (deref (subscription-fn datasource)))
-        ([datasource args] (deref (subscription-fn datasource args))))
-      {::subscription subscription-fn
-       ::sub-name     query-id})))
-
-
-;(defn make-layer2-sub-fn
-;  "Returns a function that "
-;  [get-input-db-signal meta-sub-kw sub-name path]
-;  (impl.subs/make-layer2-sub-fn get-input-db-signal meta-sub-kw sub-name path))
+(defn make-sub-fn [query-id sub-args]
+  (impl/make-sub-fn ::subscription query-id sub-args))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; reactive refresh of components

--- a/src/main/space/matterandvoid/subscriptions/impl/core.cljc
+++ b/src/main/space/matterandvoid/subscriptions/impl/core.cljc
@@ -79,12 +79,6 @@
     get-input-db-signal register-handler!
     query-id path-vec-or-fn))
 
-(defn sub-fn
-  "Takes a function that returns either a Reaction or RCursor. Returns a function that when invoked delegates to `f` and
-   derefs its output. The returned function can be used in subscriptions."
-  [meta-fn-key f]
-  (subs/sub-fn meta-fn-key f))
-
 #?(:clj
    (defmacro deflayer2-sub
      "Only supports use cases where your datasource is a hashmap.
@@ -144,4 +138,11 @@
 
 (def deref-input-signals subs/deref-input-signals)
 
+(defn sub-fn
+  "Takes a function that returns either a Reaction or RCursor. Returns a function that when invoked delegates to `f` and
+   derefs its output. The returned function can be used in subscriptions."
+  [meta-fn-key f]
+  (subs/sub-fn meta-fn-key f))
 
+(defn make-sub-fn [meta-sub-kw query-id sub-args]
+  (subs/make-sub-fn get-input-db-signal meta-sub-kw subscribe query-id sub-args))

--- a/src/main/space/matterandvoid/subscriptions/impl/fulcro.cljc
+++ b/src/main/space/matterandvoid/subscriptions/impl/fulcro.cljc
@@ -159,6 +159,9 @@
   [meta-fn-key f]
   (subs/sub-fn meta-fn-key f))
 
+(defn make-sub-fn [meta-sub-kw query-id sub-args]
+  (subs/make-sub-fn get-input-db-signal meta-sub-kw subscribe query-id sub-args))
+
 #?(:clj
    (defmacro deflayer2-sub
      "Takes a symbol for a subscription name and a way to derive a path in your fulcro app db. Returns a function subscription


### PR DESCRIPTION
Update macros to call functions at runtime instead of expanding to repeated code. Cut down on emitted codesize.