### PR TITLE
fixing hooks after refactoring

### DIFF
--- a/docs/fulcro.md
+++ b/docs/fulcro.md
@@ -66,6 +66,11 @@ Example:
 ## Use with fulcro class components
 
 ```clojure 
+(ns some.example
+  (:require 
+    [space.matterandvoid.subscriptions.fulcro :as subs :refer [defregsub reg-sub]]
+    [space.matterandvoid.subscriptions.fulcro-components :refer [with-reactive-subscriptions]]))
+    
 (defonce fulcro-app (subs/with-reactive-subscriptions (fulcro.app/fulcro-app {})))
 
 (defregsub list-idents (fn [db {:keys [list-id]}] (get db list-id)))
@@ -122,16 +127,16 @@ Example:
 (fulcro.app/mount! fulcro-app Root js/app)
 ```
 
-the `subs/with-reactive-subscriptions` call assoc'es the ::fulcro.app/state-atom to be a reagent.ratom/atom. 
+the `subs/with-reactive-subscriptions` call assoc'es the `::fulcro.app/state-atom` to be a `reagent.ratom/atom`. 
 It also assigns the rendering algorithm used by the app to use the ident-optimized render. 
 The intention of this library is that all derived data is computed using subscriptions
 and rendered with their values - this way there are never any stale components on screen - just like in re-frame.
 
 ## Use with fulcro hooks components
 
-See the `space.matterandvoid.subscriptions.react-hook-fulcro` namespace
+See the `space.matterandvoid.subscriptions.react-hooks-fulcro` namespace and the doc on [react hooks](docs/react-hooks.md) usage.
 
-# Subscriptions support passing the fulcro application of state map as a datasource
+# Subscriptions support passing the fulcro application state map as a datasource
 
 Subscriptions compute derived data and a common place to make use of that derived data is in mutations.
 

--- a/examples/fulcro_example.cljs
+++ b/examples/fulcro_example.cljs
@@ -10,6 +10,7 @@
     [com.fulcrologic.fulcro.mutations :as mut :refer [defmutation]]
     [com.fulcrologic.fulcro.dom :as dom]
     [space.matterandvoid.subscriptions.fulcro :as subs :refer [defregsub reg-sub]]
+    [space.matterandvoid.subscriptions.fulcro-components :refer [with-reactive-subscriptions]]
     [goog.object :as g]
     [taoensso.timbre :as log]))
 
@@ -172,7 +173,7 @@
 
 (defonce root (react-dom/createRoot (js/document.getElementById "app")))
 (defonce fulcro-app
-  (subs/with-reactive-subscriptions (fulcro.app/fulcro-app {:render-root! (fn [component] (.render root component))})))
+  (with-reactive-subscriptions (fulcro.app/fulcro-app {:render-root! (fn [component] (.render root component))})))
 
 (comment (fulcro.app/current-state fulcro-app))
 

--- a/src/main/space/matterandvoid/subscriptions/core.cljc
+++ b/src/main/space/matterandvoid/subscriptions/core.cljc
@@ -156,6 +156,7 @@
 
 (defn with-name
   [f sub-name]
+  (assert (fn? f) "with-name can only be called on a function")
   (vary-meta f assoc ::sub-name sub-name))
 
 #?(:cljs (def datasource-context (react/createContext nil)))

--- a/src/main/space/matterandvoid/subscriptions/fulcro.cljs
+++ b/src/main/space/matterandvoid/subscriptions/fulcro.cljs
@@ -4,7 +4,6 @@
     [com.fulcrologic.fulcro.algorithm :as-alias fulcro.algo]
     [com.fulcrologic.fulcro.application :as fulcro.app]
     [com.fulcrologic.fulcro.components :as c]
-    [com.fulcrologic.fulcro.rendering.ident-optimized-render :as ident-optimized-render]
     [space.matterandvoid.subscriptions.impl.fulcro :as impl]
     [space.matterandvoid.subscriptions.impl.subs :as impl.subs]
     [space.matterandvoid.subscriptions.impl.reagent-ratom :as ratom]

--- a/src/main/space/matterandvoid/subscriptions/impl/core.cljc
+++ b/src/main/space/matterandvoid/subscriptions/impl/core.cljc
@@ -7,6 +7,7 @@
 
 (defn get-input-db-signal [ratom] ratom)
 (defonce subs-cache_ (atom {}))
+(comment (count @subs-cache_))
 (defn get-subscription-cache [_app] subs-cache_)
 
 (defn sub-missing-name! [sub-fn]

--- a/src/test/space/matterandvoid/subscriptions/fulcro_test.cljc
+++ b/src/test/space/matterandvoid/subscriptions/fulcro_test.cljc
@@ -3,7 +3,8 @@
     [clojure.test :refer [deftest is testing use-fixtures]]
     [space.matterandvoid.subscriptions.test-subs :as subs]
     [com.fulcrologic.fulcro.application :as fulcro.app]
-    [space.matterandvoid.subscriptions.fulcro :as sut]))
+    [space.matterandvoid.subscriptions.fulcro :as sut]
+    [space.matterandvoid.subscriptions.fulcro-components :as sut2]))
 
 #?(:cljs (enable-console-print!))
 (defonce counter_ (volatile! 0))
@@ -11,7 +12,7 @@
 (deref counter_)
 
 (def start-db {:first 500 :first-sub 500 :a "hi"})
-(defonce app (sut/with-reactive-subscriptions (fulcro.app/fulcro-app {:initial-db start-db})))
+(defonce app (sut2/with-reactive-subscriptions (fulcro.app/fulcro-app {:initial-db start-db})))
 
 (use-fixtures :each
   #?(:cljs {:after (fn [] (vreset! counter_ 0))}


### PR DESCRIPTION
- Move fulcro component code to its own namespace for use-cases where you aren't using fulcro for UI
- Fix use-reaction to cleanup reaction on unmount
- Fix core.react-hooks to use the common `use-sub`
- Update examples to work again