### PR TITLE
add xform on attributes in eql

### DIFF
--- a/src/main/space/matterandvoid/subscriptions/fulcro_eql.cljc
+++ b/src/main/space/matterandvoid/subscriptions/fulcro_eql.cljc
@@ -61,16 +61,13 @@
         attr))
     (-ref->attribute [_ ref] (first ref))
     (-ref->id [_ ref]
-      ;(log/debug "-ref->id ref" ref)
       (cond (eql/ident? ref) (second ref)
             (map? ref) (let [id-key (first (filter (comp #(= % "id") name) (keys ref)))]
                          (get ref id-key))
             :else ref))
     (-entity-id [_ _ id-attr args] (get args id-attr))
     (-entity [_ fulcro-app id-attr args]
-      ;(log/info "-entity for id attr: " id-attr)
       (when (eql/ident? [id-attr (get args id-attr)])
-        ;(log/info "IDENT" [id-attr (get args id-attr)])
         (get-in (->db fulcro-app) [id-attr (get args id-attr)])))
     (-attr [_ fulcro-app id-attr attr args]
       (get-in (->db fulcro-app) [id-attr (get args id-attr) attr]))))
@@ -117,9 +114,9 @@
                                    component-query (rc/get-query component state-map)]
                                (filterv some?
                                  (map (fn [[id-attr id-value]]
-                                         (when id-value
-                                           (component-eql-sub fulcro-app {query-key component-query, id-attr id-value})))
-                                       idents))))))]
+                                        (when id-value
+                                          (component-eql-sub fulcro-app {query-key component-query, id-attr id-value})))
+                                   idents))))))]
     (fulcro.subs/with-name
       (sub-fn sub)
       sub-cache-name)))

--- a/src/main/space/matterandvoid/subscriptions/xtdb_eql.clj
+++ b/src/main/space/matterandvoid/subscriptions/xtdb_eql.clj
@@ -26,6 +26,8 @@
       (db? v) v
       :else (throw (Exception. (str "Unsupported value passed to ->db: " (pr-str node-or-db)))))))
 
+(defn map->id-ref [m] (first (filter (fn [[k]] (= (name k) "id")) m)))
+
 (def xtdb-data-source
   (reify proto/IDataSource
     (-attribute-subscription-fn [this id-attr attr]
@@ -34,7 +36,7 @@
           (fn []
             (impl/missing-id-check! id-attr attr args)
             (proto/-attr this db_ id-attr attr args)))))
-    (-ref->attribute [_ ref] :xt/id)
+    (-ref->attribute [_ ref] (if (map? ref) (first (map->id-ref ref)) :xt/id))
     (-ref->id [_ ref]
       (cond (eql/ident? ref)
             (second ref)

--- a/src/test/space/matterandvoid/subscriptions/datalevin_eql_test.clj
+++ b/src/test/space/matterandvoid/subscriptions/datalevin_eql_test.clj
@@ -213,6 +213,15 @@
                                              {:user/name "user 2", :user/id :user-2, :user/friends #{(ent [:user/id :user-2]) (ent [:user/id :user-3]) (ent [:user/id :user-1]) (ent [:user/id :user-5])}}]}]}
             out)))))
 
+(deftest xform-test
+  (testing "transform an attribute"
+    (is
+      {:user/name "USER 1", :user/id :user-1}
+      (<sub db_ [::user {'upper-case-name (fn [e] (update e :user/name str/upper-case))
+                         'uppercase       str/upper-case
+                         :user/id         :user-1
+                         sut/query-key    [(list :user/name {sut/xform-fn-key 'uppercase}) :user/id]}]))))
+
 (comment
   (<sub db_ [::list {:list/id :list-1 sut/query-key [{:list/items list-member-q}
                                                      {:list/members {:comment/id [:comment/id :comment/text] :todo/id [:todo/id :todo/text]}}]}])

--- a/src/test/space/matterandvoid/subscriptions/fulcro_eql_fn_vars_test.cljc
+++ b/src/test/space/matterandvoid/subscriptions/fulcro_eql_fn_vars_test.cljc
@@ -180,9 +180,8 @@
       (is (=
             {:todo/id       :todo-3,
              :todo/comments [{:comment/sub-comments [[:comment/id :comment-2]], :comment/id :comment-1, :comment/text "FIRST COMMENT" :comment/author [:user/id :user-1]}
-                             {:comment/sub-comments sut/missing-val,
-                              :comment/id           :comment-3,
-                              :comment/text         "THIRD COMMENT"}]}
+                             {:comment/id   :comment-3,
+                              :comment/text "THIRD COMMENT"}]}
             (<sub app [todo-sub {:todo/id :todo-3 sut/query-key [:todo/id {:todo/comments ['*]}]}]))))))
 
 (deftest recursive-join-queries
@@ -228,11 +227,10 @@
 (deftest queries-test
   (testing "props"
     (let [out1 {:todo/id :todo-1 :todo/text "todo 1"}
-          out2 #:todo{:comment  [:comment/id :comment-1],
-                      :comments sut/missing-val
-                      :author   [:bot/id :bot-1],
-                      :id       :todo-1,
-                      :text     "todo 1"}]
+          out2 #:todo{:comment [:comment/id :comment-1],
+                      :author  [:bot/id :bot-1],
+                      :id      :todo-1,
+                      :text    "todo 1"}]
       (is (= out1 (<sub app [todo-sub {:todo/id :todo-1 sut/query-key [:todo/id :todo/text]}])))
       (is (= out1 (todo-sub app {:todo/id :todo-1 sut/query-key [:todo/id :todo/text]})))
       (is (= out1 (todo-sub (fulcro.app/current-state app) {:todo/id :todo-1 sut/query-key [:todo/id :todo/text]})))
@@ -242,18 +240,14 @@
 
   (testing "entity subscription with no query returns all attributes"
     (is (=
-          {:list/items   [{:todo/comments sut/missing-val
-                           :todo/author   {:user/friends [[:user/id :user-2] [:user/id :user-1] [:user/id :user-3]], :user/name "user 2", :user/id :user-2},
-                           :todo/comment  sut/missing-val
-                           :todo/text     "todo 2",
-                           :todo/id       :todo-2}
+          {:list/items   [{:todo/author {:user/friends [[:user/id :user-2] [:user/id :user-1] [:user/id :user-3]], :user/name "user 2", :user/id :user-2},
+                           :todo/text   "todo 2",
+                           :todo/id     :todo-2}
                           {:comment/sub-comments [[:comment/id :comment-2]], :comment/id :comment-1, :comment/text "FIRST COMMENT"}],
            :list/members [{:comment/sub-comments [[:comment/id :comment-2]], :comment/id :comment-1, :comment/text "FIRST COMMENT"}
-                          {:todo/comments sut/missing-val
-                           :todo/author   {:user/friends [[:user/id :user-2] [:user/id :user-1] [:user/id :user-3]], :user/name "user 2", :user/id :user-2},
-                           :todo/comment  sut/missing-val
-                           :todo/text     "todo 2",
-                           :todo/id       :todo-2}],
+                          {:todo/author {:user/friends [[:user/id :user-2] [:user/id :user-1] [:user/id :user-3]], :user/name "user 2", :user/id :user-2},
+                           :todo/text   "todo 2",
+                           :todo/id     :todo-2}],
            :list/name    "first list",
            :list/id      :list-1}
           (<sub app [list-sub {:list/id :list-1}])))))
@@ -262,7 +256,7 @@
   (is (=
         {:todo/id    :todo-with-form,
          :todo/text  "todo with-form",
-         ::fs/config {::fs/id             [:todo/id :todo-with-form], ::fs/fields #{:todo/text}, ::fs/complete? nil, ::fs/subforms {},
+         ::fs/config {::fs/id             [:todo/id :todo-with-form], ::fs/fields #{:todo/text}, ::fs/subforms {},
                       ::fs/pristine-state {:todo/text "todo with-form"}}}
         (todo-with-form-sub app {:todo/id      :todo-with-form
                                  sut/query-key (rc/get-query todo-with-form-component)}))))

--- a/src/test/space/matterandvoid/subscriptions/fulcro_eql_test.cljc
+++ b/src/test/space/matterandvoid/subscriptions/fulcro_eql_test.cljc
@@ -4,8 +4,6 @@
     [space.matterandvoid.subscriptions.impl.reagent-ratom :as r]
     [space.matterandvoid.subscriptions.fulcro :as subs :refer [<sub defsub]]
     [com.fulcrologic.fulcro.application :as fulcro.app]
-    [edn-query-language.core :as eql]
-    [com.fulcrologic.fulcro.algorithms.merge :as merge]
     [com.fulcrologic.fulcro.raw.components :as rc]
     [taoensso.timbre :as log]
     [clojure.test :refer [deftest is testing]]))
@@ -13,7 +11,6 @@
 (log/set-level! :warn)
 #?(:cljs (enable-console-print!))
 (set! *print-namespace-maps* false)
-
 
 (def user-comp (sut/nc {:query [:user/id :user/name {:user/friends '...}] :name ::user :ident :user/id}))
 (def bot-comp (sut/nc {:query [:bot/id :bot/name] :name ::bot :ident :bot/id}))

--- a/src/test/space/matterandvoid/subscriptions/fulcro_eql_test.cljc
+++ b/src/test/space/matterandvoid/subscriptions/fulcro_eql_test.cljc
@@ -35,13 +35,11 @@
 
 (run! sut/register-component-subs! [user-comp bot-comp comment-comp todo-comp list-comp human-comp])
 (comment
-  (<sub app [::list {:list/id :list-1 sut/query-key [ {:list/items list-member-q } ]}])
+  (<sub app [::list {:list/id :list-1 sut/query-key [{:list/items list-member-q}]}])
 
   (<sub app [::list {:list/id :list-1 sut/query-key [{:list/items
                                                       {:comment/id [:comment/id :comment/text {:comment/sub-comments '...}]
-                                                       :todo/id [:todo/id :todo/text]}
-                                                      }
-                                                     ]}])
+                                                       :todo/id    [:todo/id :todo/text]}}]}])
   (<sub app [::todo {:todo/id :todo-1 sut/query-key [:todo/author]}])
   (sut/eql-query-keys-by-type (sut/get-query todo-comp)
     (fn [join-ast] (-> join-ast :component sut/class->registry-key))))
@@ -166,9 +164,8 @@
       (is (=
             {:todo/id       :todo-3,
              :todo/comments [{:comment/sub-comments [[:comment/id :comment-2]], :comment/id :comment-1, :comment/text "FIRST COMMENT"}
-                             {:comment/sub-comments sut/missing-val,
-                              :comment/id           :comment-3,
-                              :comment/text         "THIRD COMMENT"}]}
+                             {:comment/id   :comment-3,
+                              :comment/text "THIRD COMMENT"}]}
             (<sub app [::todo {:todo/id :todo-3 sut/query-key [:todo/id {:todo/comments ['*]}]}]))))))
 
 (deftest recursive-join-queries
@@ -215,27 +212,22 @@
   (testing "props"
     (is (= {:todo/id :todo-1 :todo/text "todo 1"} (<sub app [::todo {:todo/id :todo-1 sut/query-key [:todo/id :todo/text]}])))
     (is (=
-          #:todo{:comment  [:comment/id :comment-1],
-                 :comments sut/missing-val
-                 :author   [:bot/id :bot-1],
-                 :id       :todo-1,
-                 :text     "todo 1"}
+          #:todo{:comment [:comment/id :comment-1],
+                 :author  [:bot/id :bot-1],
+                 :id      :todo-1,
+                 :text    "todo 1"}
           (<sub app [::todo {:todo/id :todo-1 sut/query-key ['* :todo/text]}]))))
 
   (testing "entity subscription with no query returns all attributes"
     (is (=
-          {:list/items   [{:todo/comments sut/missing-val
-                           :todo/author   {:user/friends [[:user/id :user-2] [:user/id :user-1] [:user/id :user-3]], :user/name "user 2", :user/id :user-2},
-                           :todo/comment  sut/missing-val
-                           :todo/text     "todo 2",
-                           :todo/id       :todo-2}
+          {:list/items   [{:todo/author {:user/friends [[:user/id :user-2] [:user/id :user-1] [:user/id :user-3]], :user/name "user 2", :user/id :user-2},
+                           :todo/text   "todo 2",
+                           :todo/id     :todo-2}
                           {:comment/sub-comments [[:comment/id :comment-2]], :comment/id :comment-1, :comment/text "FIRST COMMENT"}],
            :list/members [{:comment/sub-comments [[:comment/id :comment-2]], :comment/id :comment-1, :comment/text "FIRST COMMENT"}
-                          {:todo/comments sut/missing-val
-                           :todo/author   {:user/friends [[:user/id :user-2] [:user/id :user-1] [:user/id :user-3]], :user/name "user 2", :user/id :user-2},
-                           :todo/comment  sut/missing-val
-                           :todo/text     "todo 2",
-                           :todo/id       :todo-2}],
+                          {:todo/author {:user/friends [[:user/id :user-2] [:user/id :user-1] [:user/id :user-3]], :user/name "user 2", :user/id :user-2},
+                           :todo/text   "todo 2",
+                           :todo/id     :todo-2}],
            :list/name    "first list",
            :list/id      :list-1}
           (<sub app [::list {:list/id :list-1}])))))

--- a/tests.edn
+++ b/tests.edn
@@ -1,6 +1,7 @@
 #kaocha/v1
         {:tests [{:id :xtdb-eql :test-paths ["src/test"] :ns-patterns [".*xtdb-eql-test$"]}
                  {:id :datalevin-eql :test-paths ["src/test"] :ns-patterns [".*datalevin-eql-test$"]}
-                 {:id :fulcro-eql :test-paths ["src/test"] :ns-patterns [".*fulcro-eql-test$"]}
+                 {:id :fulcro-eql :test-paths ["src/test"] :ns-patterns [".*fulcro-eql-test$"
+                                                                         ".*fulcro-eql-fn-vars-test$"]}
                  {:id :core :test-paths ["src/test"] :ns-patterns [".*core-test$"
                                                                    ".*subs-test$"]}]}


### PR DESCRIPTION
Fixes for EQL support with datalevin and xtdb
- plain joins can figure out the join key attribute via the fulcro component so we don't need to use `-ref->attribute` at runtime.
- allow support for refs that return maps as well as light entities which only contain `:db/id`.

Add `xform` support for plain attributes in addition to in recursive position.

Instead of returning `::missing-val` or `nil` when an attribute isn't present, do not include it in the output.
This is aligned with datomic pull semantics:
https://docs.datomic.com/on-prem/query/pull.html#missing-attributes

> In the absence of a default, attribute specifications that do not match an entity are omitted from that entity's result map, rather than e.g. appearing with a nil value.