### PR TITLE
fix eql datalevin

### DIFF
--- a/src/test/space/matterandvoid/subscriptions/datalevin_eql_test.clj
+++ b/src/test/space/matterandvoid/subscriptions/datalevin_eql_test.clj
@@ -98,7 +98,6 @@
 
 (defonce db_ (r/atom (d/db conn)))
 (defn ent [ref] (d/entity @db_ (d/entid @db_ ref)))
-;(<sub db_ [::todo {:todo/id :todo-1 sut/query-key [:todo/id :todo/author]}])
 (deftest union-queries-test
   (testing "to-one union queries"
     (is (= {:todo/id :todo-1, :todo/author {:bot/name "bot 1", :bot/id :bot-1}}


### PR DESCRIPTION
add a guard when looking up entities in datalevin to prevent exceptions being thrown when refs is a collection. 