### PR TITLE
make use-sub memo by default, use-datasource helpers

### DIFF
--- a/src/main/space/matterandvoid/subscriptions/react_hooks.clj
+++ b/src/main/space/matterandvoid/subscriptions/react_hooks.clj
@@ -4,7 +4,7 @@
     [space.matterandvoid.subscriptions.impl.react-hooks-common :as common]
     [space.matterandvoid.subscriptions.impl.reagent-ratom :as ratom]))
 
-(defmacro use-sub-memo
+(defmacro use-sub
   "Macro that expands expands to `use-sub`, memoizes the subscription vector so that the underlying subscription
   is reused across re-renders by React. If your subscription vector contains an arguments map literal, it is memoized with dependencies
   being the values of the map. If you pass a symbol as the arguments the symbol will be used as the dependency for useMemo;

--- a/src/main/space/matterandvoid/subscriptions/react_hooks.cljs
+++ b/src/main/space/matterandvoid/subscriptions/react_hooks.cljs
@@ -9,7 +9,7 @@
 
 (defn use-context [c] (react/useContext c))
 
-(defn use-sub
+(defn use-sub-fn
   "A react hook that subscribes to a subscription, the return value of the hook is the return value of the
   subscription which will cause the consuming React function component to update when the subscription's value updates.
 
@@ -30,10 +30,10 @@
    (common/use-sub subs/subscribe datasource query equal?))
 
   ([datasource query]
-   (use-sub datasource query identical?))
+   (use-sub-fn datasource query identical?))
 
   ([query]
-   (use-sub (react/useContext subs/datasource-context) query identical?)))
+   (use-sub-fn (react/useContext subs/datasource-context) query identical?)))
 
 (defn use-reaction
   "Takes a Reagent Reaction and rerenders the UI component when the Reaction's value changes.
@@ -47,3 +47,6 @@
   [reaction]
   (let [ref (react/useRef reaction)]
     (common/use-reaction (.-current ref))))
+
+(defn use-datasource "Returns the currently bound datasource-context using react/useContext."
+  [] (react/useContext subs/datasource-context))

--- a/src/main/space/matterandvoid/subscriptions/react_hooks_fulcro.clj
+++ b/src/main/space/matterandvoid/subscriptions/react_hooks_fulcro.clj
@@ -4,7 +4,7 @@
     [space.matterandvoid.subscriptions.fulcro :as subs]
     [space.matterandvoid.subscriptions.impl.react-hooks-common :as common]))
 
-(defmacro use-sub-memo
+(defmacro use-sub
   "Macro that expands expands to `use-sub`, memoizes the subscription vector so that the underlying subscription
   is reused across re-renders by React. If your subscription vector contains an arguments map literal, it is memoized with dependencies
   being the values of the map. If you pass a symbol as the arguments the symbol will be used as the dependency for useMemo;

--- a/src/main/space/matterandvoid/subscriptions/react_hooks_fulcro.cljs
+++ b/src/main/space/matterandvoid/subscriptions/react_hooks_fulcro.cljs
@@ -10,7 +10,7 @@
 
 (defn use-context [c] (react/useContext c))
 
-(defn use-sub
+(defn use-sub-fn
   "A react hook that subscribes to a subscription, the return value of the hook is the return value of the
   subscription which will cause the consuming React function component to update when the subscription's value updates.
 
@@ -32,10 +32,10 @@
    (common/use-sub subs/subscribe datasource query equal?))
 
   ([datasource query]
-   (use-sub datasource query identical?))
+   (use-sub-fn datasource query identical?))
 
   ([query]
-   (use-sub (react/useContext subs/datasource-context) query identical?)))
+   (use-sub-fn (react/useContext subs/datasource-context) query identical?)))
 
 (defn use-reaction
   "Takes a Reagent Reaction and rerenders the UI component when the Reaction's value changes.
@@ -49,3 +49,6 @@
   [reaction]
   (let [ref (react/useRef reaction)]
     (common/use-reaction (.-current ref))))
+
+(defn use-fulcro-app "Returns the currently bound datasource-context using react/useContext."
+  [] (react/useContext subs/datasource-context))


### PR DESCRIPTION
- Make `use-sub` default to the memo macro.
- add context helper fns