### PR TITLE
Fix caching subscriptions in react use-sub hook

### DIFF
--- a/src/main/space/matterandvoid/subscriptions/impl/reagent_ratom.cljs
+++ b/src/main/space/matterandvoid/subscriptions/impl/reagent_ratom.cljs
@@ -28,9 +28,20 @@
    are any options accepted by a Reaction and will be set on the newly created
    Reaction. Sets the newly created Reaction to the `key` on `obj`."
   [f obj key run opts] (reagent.ratom/run-in-reaction f obj key run opts))
-(defn add-on-dispose! [a-ratom f] (reagent.ratom/add-on-dispose! a-ratom f))
+
 (defn reaction? [r] (instance? reagent.ratom/Reaction r))
 (defn cursor? [r] (instance? reagent.ratom/RCursor r))
+
+(defn add-on-dispose!
+  "Allows adding a disposal callback for Reactions as well as Cursors."
+  [^clj a-ratom on-dispose]
+  (cond
+    (reaction? a-ratom)
+    (reagent.ratom/add-on-dispose! a-ratom on-dispose)
+
+    (cursor? a-ratom)
+    (set! (.-on-dispose a-ratom) on-dispose)))
+
 (defn dispose! [^clj a-ratom]
   (if (cursor? a-ratom)
     (if (.-on-dispose a-ratom)
@@ -38,6 +49,7 @@
       (when (.-reaction a-ratom)
         (reagent.ratom/dispose! (.-reaction a-ratom))))
     (reagent.ratom/dispose! a-ratom)))
+
 (defn ^boolean reactive-context? [] (reagent.ratom/reactive?))
 
 (defn reagent-id

--- a/src/main/space/matterandvoid/subscriptions/impl/subs.cljc
+++ b/src/main/space/matterandvoid/subscriptions/impl/subs.cljc
@@ -58,8 +58,7 @@
       ;(log/debug "CACHING REACTION with KEY: " cache-key)
       ;; when this reaction is no longer being used, remove it from the cache
 
-      (when (ratom/reaction? reaction-or-cursor) (ratom/add-on-dispose! reaction-or-cursor on-dispose))
-      (when (ratom/cursor? reaction-or-cursor) (set! (.-on-dispose reaction-or-cursor) on-dispose))
+      (ratom/add-on-dispose! reaction-or-cursor on-dispose)
       (swap! subscription-cache
         (fn [query-cache]
           (when ratom/debug-enabled?


### PR DESCRIPTION
There was a bug:
- two components used the same subscription
- one of the components unmounts, the subscription is evicted from subscription cache
- the component that is still mounted would have a nil subscription

The error was calling `dispose!` on unmount. The solution is to use reference counting, storing the counter on the subscription itself (this will be either a `reagent.ratom.Reaction` or `reagent.ratom.Cursor`). When the reference counter is zero it is safe to dispose of.